### PR TITLE
nrf52: 使NRF_SDK和QMK保持独立

### DIFF
--- a/platforms/nrf52/_wait.h
+++ b/platforms/nrf52/_wait.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#undef MIN
+#undef MAX
 #include "nrf_delay.h"
 
 #define wait_ms(ms)       \

--- a/platforms/nrf52/gpio.h
+++ b/platforms/nrf52/gpio.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#undef MIN
+#undef MAX
 #include "pin_defs.h"
 #include "nrf_gpio.h"
 


### PR DESCRIPTION
本次更改点：在nrf平台相关代码头文件被包含前取消qmk中已有且被包含的宏定义，解决编译问题的同时，解耦QMK和NRF_SDK